### PR TITLE
Fix ImageBlock Upload

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.0.4 (2016-01-30)
+==================
+* ImageBlock - tune save to work with either file system or remote storage
+
 1.0.3 (2015-06-19)
 ==================
 * Added SimpleImageBlock - an ImageBlock that doesn't include

--- a/pageblocks/models.py
+++ b/pageblocks/models.py
@@ -217,13 +217,14 @@ class ImageBlock(BasePageBlock):
             return None
         now = datetime.now()
         path = "images/%04d/%02d/%02d/" % (now.year, now.month, now.day)
+        full_filename = path + "%s.%s" % (basename, ext)
+
         try:
             os.makedirs(settings.MEDIA_ROOT + "/" + path)
+            fd = self.image.storage.open(
+                settings.MEDIA_ROOT + "/" + full_filename, 'wb')
         except:
-            pass
-        full_filename = path + "%s.%s" % (basename, ext)
-        fd = self.image.storage.open(
-            settings.MEDIA_ROOT + "/" + full_filename, 'wb')
+            fd = self.image.storage.open(full_filename, 'wb')
 
         for chunk in f.chunks():
             fd.write(chunk)
@@ -415,9 +416,9 @@ class ImagePullQuoteBlock(BasePageBlock):
 # Using the HTMLBlockWYSIWYG
 # Install tinymce into your project: http://code.google.com/p/django-tinymce/
 # Override the admin/base-site.html:
-## Include: <script type="text/javascript"
-##          src="/site_media/js/tiny_mce/tiny_mce.js"></script>
-## And, add the init code immediately thereafter.
+# Include: <script type="text/javascript"
+#          src="/site_media/js/tiny_mce/tiny_mce.js"></script>
+# And, add the init code immediately thereafter.
 # To your settings_shared.py add 'pageblocks.HTMLBlockWYSIWYG'.
 # Consider removing the generic HTMLBlock if you don't need it.
 #  Reduces confusion.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools import setup
 
 setup(
     name="django-pageblocks",
-    version="1.0.3",
+    version="1.0.4",
     author="Anders Pearson",
     author_email="anders@columbia.edu",
     url="https://github.com/ccnmtl/django-pageblocks",


### PR DESCRIPTION
Various changes in our settings & S3 supporting modules inadvertently broke ImageBlock's upload to S3. This change allows uploads to work via a local MEDIA_ROOT or a configured S3 bucket.